### PR TITLE
refactored dockerfile for uv-specific syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-
 COPY pyproject.toml ./
-COPY uv.lock ./
-RUN pip install --upgrade pip && pip install uv
-RUN uv pip install --system --requirement uv.lock
+
+RUN pip install --upgrade pip \
+    && pip install uv \
+    && uv install  # <-- installs dependencies based on pyproject.toml, no uv.lock needed
 
 COPY . .
 


### PR DESCRIPTION
# Description

This pull request simplifies the Python dependency installation process in the `Dockerfile` by switching to a more modern and streamlined approach using `uv install`. This change reduces unnecessary steps and files, making the build process cleaner and easier to maintain.

Dependency installation improvements:

* Removed the copying of `uv.lock` and the separate installation step for dependencies from `uv.lock`, as these are no longer needed.
* Updated the installation command to use `uv install`, which installs dependencies directly from `pyproject.toml` and eliminates the need for a lock file during the build.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Chore
