### PR TITLE
Updated SQL for APOD staging and quality checks

### DIFF
--- a/SQL/data_quality/QUALITY_NASA_APOD.sql
+++ b/SQL/data_quality/QUALITY_NASA_APOD.sql
@@ -7,6 +7,4 @@ SELECT
     thumbnail_url,
     copyright
 FROM STAGED.NASA_APOD
-WHERE title IS NULL
-    OR explanation IS NULL
-    OR url IS NULL;
+WHERE title IS NULL;

--- a/SQL/staging/STAGED_NASA_APOD.sql
+++ b/SQL/staging/STAGED_NASA_APOD.sql
@@ -8,7 +8,4 @@ SELECT
     thumbnail_url,
     copyright
 FROM RAW_DATA.NASA_APOD
-WHERE date IS NOT NULL
-    AND title IS NOT NULL
-    AND url IS NOT NULL
-    AND explanation IS NOT NULL;
+WHERE title IS NOT NULL;


### PR DESCRIPTION
# Description

This pull request updates the data quality and staging SQL queries for NASA APOD by changing the filtering criteria to only consider whether the `title` field is null or not. Previously, multiple fields were checked for null values, but now only the `title` field is used in the WHERE clauses.

Data quality query updates:

* In `SQL/data_quality/QUALITY_NASA_APOD.sql`, the WHERE clause was simplified to filter only rows where `title` is null, instead of also checking `explanation` and `url`.

Staging query updates:

* In `SQL/staging/STAGED_NASA_APOD.sql`, the WHERE clause now selects only rows where `title` is not null, removing checks for `date`, `url`, and `explanation`.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Chore
